### PR TITLE
Release pipeline

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -1,0 +1,35 @@
+name: Publish Python package to PyPI
+
+on:
+  push:
+    tags:
+     - '*'
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python package to PyPI
+    permissions:
+      id-token: write 
+    environment: release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@main
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.12'
+    - name: Install pypa/setuptools
+      run: >-
+        python -m
+        pip install wheel
+    - name: Extract tag name
+      id: tag
+      run: echo ::set-output name=TAG_NAME::$(echo $GITHUB_REF | cut -d / -f 3)
+    - name: Update version in setup.py
+      run: >-
+        sed -i "s/{{VERSION_PLACEHOLDER}}/${{ steps.tag.outputs.TAG_NAME }}/g" setup.py
+    - name: Build a binary wheel
+      run: >-
+        python setup.py sdist bdist_wheel
+    - name: Publish package to PyPI
+      uses:  pypa/gh-action-pypi-publish@release/v1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ README = open(os.path.join(os.path.dirname(__file__), "README.md")).read()
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
-version = "0.1.0"
+version = "{{VERSION_PLACEHOLDER}}"
 
 setup(
     name="syntho-cli",


### PR DESCRIPTION
- Add release pipeline that publishes a new version based on new tags. Pipeline will run if a tag gets created.

Let start with 0.1.0 for example as the first tag. An improvement to this would be to introduce something like semantic release, but this is a good start for now.